### PR TITLE
fixed shrinking vector

### DIFF
--- a/lain/src/mutatable.rs
+++ b/lain/src/mutatable.rs
@@ -164,7 +164,7 @@ fn shrink_vec<T, R: Rng>(vec: &mut Vec<T>, mutator: &mut Mutator<R>) {
         VecResizeCount::Quarter => vec.len() / 4,
         VecResizeCount::Half => vec.len() / 2,
         VecResizeCount::ThreeQuarters => vec.len() - (vec.len() / 4),
-        VecResizeCount::FixedBytes => mutator.gen_range(1, 9),
+        VecResizeCount::FixedBytes => min(mutator.gen_range(1, 9), vec.len()),
         VecResizeCount::AllBytes => vec.len(),
     };
 


### PR DESCRIPTION
This fixes an issues with Vec<_> mutation where the mutator can actually try to remove more bytes than exist in the vector. This causes a panic.

The fix here is pretty simple, we just take the min of the length of the vector or the randomly generated range.