### PR TITLE
Update example Cargo.toml

### DIFF
--- a/examples/example_fuzzer/Cargo.toml
+++ b/examples/example_fuzzer/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Lain Dev"]
 edition = "2018"
 
 [dependencies]
-lain = { version = "0.2", path = "../../lain" }
+lain = { version = "*", path = "../../lain" }
 ctrlc = "3.1"


### PR DESCRIPTION
Just a quick fix for the version inside the example, otherwise you get:
```
error: failed to select a version for the requirement `lain = "^0.2"`
  candidate versions found which didn't match: 0.5.0
  location searched: XXX/lain/lain
required by package `example_fuzzer v0.1.0 (XXX/lain/examples/example_fuzzer)
```