### PR TITLE
Fix warnings

### DIFF
--- a/lain/src/lib.rs
+++ b/lain/src/lib.rs
@@ -99,7 +99,6 @@
 //! comments.
 
 #![feature(specialization)]
-#![feature(min_const_generics)]
 
 extern crate num;
 extern crate num_derive;

--- a/lain/src/mutatable.rs
+++ b/lain/src/mutatable.rs
@@ -49,9 +49,7 @@ fn grow_vec<T: NewFuzzed + SerializedSize, R: Rng>(
             VecResizeCount::Half => vec.len() / 2,
             VecResizeCount::ThreeQuarters => vec.len() - (vec.len() / 4),
             VecResizeCount::FixedBytes => mutator.gen_range(1, 9),
-            VecResizeCount::AllBytes => {
-                mutator.gen_range(1, vec.len() + 1)
-            }
+            VecResizeCount::AllBytes => mutator.gen_range(1, vec.len() + 1),
         }
     };
 
@@ -316,7 +314,7 @@ where
         mutator: &mut Mutator<R>,
         constraints: Option<&Constraints<Self::RangeType>>,
     ) {
-        let mut constraints = constraints.and_then(|c| {
+        let constraints = constraints.and_then(|c| {
             if c.max_size.is_none() {
                 None
             } else {
@@ -632,7 +630,7 @@ where
             }
             None => {
                 if mutator.gen_chance(CHANCE_TO_FLIP_OPTION_STATE) {
-                    let mut new_item = T::new_fuzzed(mutator, constraints);
+                    let new_item = T::new_fuzzed(mutator, constraints);
 
                     *self = Some(new_item);
                 }

--- a/lain/src/new_fuzzed.rs
+++ b/lain/src/new_fuzzed.rs
@@ -774,7 +774,7 @@ macro_rules! impl_new_fuzzed_array {
                 type RangeType = usize;
 
                 fn new_fuzzed<R: Rng>(mutator: &mut Mutator<R>, constraints: Option<&Constraints<Self::RangeType>>) -> [T; $size] {
-                    let mut per_item_max_size: Option<usize> = constraints.and_then(|c| c.max_size.as_ref().and_then(|size| Some(*size / $size)));
+                    let per_item_max_size: Option<usize> = constraints.and_then(|c| c.max_size.as_ref().and_then(|size| Some(*size / $size)));
 
                     let mut output: MaybeUninit<[T; $size]> = MaybeUninit::uninit();
                     let arr_ptr = output.as_mut_ptr() as *mut T;
@@ -828,7 +828,7 @@ macro_rules! impl_new_fuzzed_array {
                 default type RangeType = usize;
 
                 default fn new_fuzzed<R: Rng>(mutator: &mut Mutator<R>, constraints: Option<&Constraints<Self::RangeType>>) -> [T; $size] {
-                    let mut per_item_max_size: Option<usize> = constraints.and_then(|c| c.max_size.as_ref().and_then(|size| Some(*size / $size)));
+                    let per_item_max_size: Option<usize> = constraints.and_then(|c| c.max_size.as_ref().and_then(|size| Some(*size / $size)));
 
                     let mut output: MaybeUninit<[T; $size]> = MaybeUninit::uninit();
                     let arr_ptr = output.as_mut_ptr() as *mut T;

--- a/lain_derive/src/internals/ast.rs
+++ b/lain_derive/src/internals/ast.rs
@@ -137,7 +137,7 @@ fn fields_from_ast<'a>(cx: &Ctxt, fields: &'a Punctuated<syn::Field, Token![,]>)
             bitfield_bits += bits;
 
             let bits_in_type: usize;
-            
+
             let bitfield_type = field.attrs.bitfield_type().unwrap_or(&field.ty);
             if is_primitive_type(bitfield_type, "u8") {
                 bits_in_type = 8

--- a/testsuite/benches/benchmark_generating_fuzzed_struct.rs
+++ b/testsuite/benches/benchmark_generating_fuzzed_struct.rs
@@ -52,7 +52,7 @@ fn bench_new_fuzzed_1000(c: &mut Criterion) {
     c.bench(
         function_name.as_ref(),
         Benchmark::new("fuzz", move |b| {
-            let mut mutator = Mutator::new(lain::rand::rngs::SmallRng::from_seed([0u8; 16]));
+            let mut mutator = Mutator::new(lain::rand::rngs::SmallRng::from_seed([0u8; 32]));
             b.iter(|| {
                 let s = NestedStruct::new_fuzzed(&mut mutator, None);
                 black_box(s);
@@ -69,8 +69,8 @@ fn bench_in_place_mutation(c: &mut Criterion) {
     c.bench(
         function_name.as_ref(),
         Benchmark::new("fuzz", move |b| {
-            let mut mutator = Mutator::new(lain::rand::rngs::SmallRng::from_seed([0u8; 16]));
-            let mut s = NestedStruct::new_fuzzed(&mut mutator, None);
+            let mut mutator = Mutator::new(lain::rand::rngs::SmallRng::from_seed([0u8; 32]));
+            let s = NestedStruct::new_fuzzed(&mut mutator, None);
             b.iter(|| {
                 let mut s = s.clone();
                 let state = mutator.get_corpus_state();

--- a/testsuite/src/lib.rs
+++ b/testsuite/src/lib.rs
@@ -232,11 +232,10 @@ mod test {
             b: u8,
         }
 
-        let mut instance;
         let mut mutator = get_mutator();
 
         for _i in 0..10000 {
-            instance = Foo::new_fuzzed(&mut mutator, None);
+            Foo::new_fuzzed(&mut mutator, None);
         }
     }
 
@@ -792,7 +791,7 @@ mod test {
             b: u32,
         }
 
-        let mut s = IncompleteBitfield { a: 0, b: 1 };
+        let s = IncompleteBitfield { a: 0, b: 1 };
 
         assert_eq!(IncompleteBitfield::min_nonzero_elements_size(), 4);
 
@@ -906,8 +905,8 @@ mod test {
 
         let mut mutator = get_mutator();
 
-        let mut obj = Foo::new_fuzzed(&mut mutator, Some(&constraints));
-        for i in 0..1000 {
+        let mut obj;
+        for _i in 0..1000 {
             obj = Foo::new_fuzzed(&mut mutator, Some(&constraints));
             assert!(obj.serialized_size() <= MAX_SIZE);
 
@@ -924,8 +923,8 @@ mod test {
             );
         }
 
-        let mut baz = Baz::new_fuzzed(&mut mutator, Some(&constraints));
-        for i in 0..1000 {
+        let mut baz;
+        for _i in 0..1000 {
             baz = Baz::new_fuzzed(&mut mutator, Some(&constraints));
             assert!(baz.serialized_size() <= MAX_SIZE);
 
@@ -971,7 +970,7 @@ mod test {
 
         // this breaks at 72 iterations which is fine. would break at a different iteration
         // with a different seed
-        for i in 0..50 {
+        for _i in 0..50 {
             let prev_obj = obj.clone();
             obj.mutate(&mut mutator, None);
 


### PR DESCRIPTION
Here's the remaining warnings:
```
warning: the feature `specialization` is incomplete and may not be safe to use and/or cause compiler crashes
   --> lain/src/lib.rs:101:12
    |
101 | #![feature(specialization)]
    |            ^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #31844 <https://github.com/rust-lang/rust/issues/31844> for more information
    = help: consider using `min_specialization` instead, which is more stable and complete

warning: field is never read: `all_chances_succeed`
  --> lain/src/mutator.rs:35:5
   |
35 |     all_chances_succeed: bool,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: `lain` (lib test) generated 2 warnings
```

(`min_specialization` doesn't seem to work here)